### PR TITLE
Fix bug with remapped_gfn not reactivating 

### DIFF
--- a/src/libdrakvuf/vmi.c
+++ b/src/libdrakvuf/vmi.c
@@ -804,6 +804,8 @@ void remove_trap(drakvuf_t drakvuf,
                 remove_trap(drakvuf, &container->breakpoint.guard2);
 
                 g_hash_table_remove(drakvuf->breakpoint_lookup_pa, &container->breakpoint.pa);
+                
+                remapped_gfn->active = 0;
             }
 
             break;


### PR DESCRIPTION
As far as I understand right now:

1. This activates remapped gfns if the trap is added for the first time: https://github.com/CERT-Polska/drakvuf/blob/master/src/libdrakvuf/vmi.c#L1060
2. This sets mappings back to "normal" once trap is removed: https://github.com/CERT-Polska/drakvuf/blob/master/src/libdrakvuf/vmi.c#L822
3. If the trap is added once again, remapped gfns are not reactivated because `remapped_gfn->active` is still set to `1` and nowhere it is set to zero?

I have no idea what would be the exact impact of the proposed patch, but intuitively seems to solve the above issue?

/cc @sasza8